### PR TITLE
Fix HitObject strain to star conversion

### DIFF
--- a/osucatch-editor-realtimeviewer/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
+++ b/osucatch-editor-realtimeviewer/osu.Game/Rulesets/Difficulty/Skills/StrainSkill.cs
@@ -55,7 +55,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             }
 
             double strain = StrainValueAt(current);
-            current.DifficultyToLast = strain * difficulty_multiplier / (1 - DecayWeight);
+            current.DifficultyToLast = Math.Sqrt(strain / (1 - DecayWeight)) * difficulty_multiplier;
             currentSectionPeak = Math.Max(strain, currentSectionPeak);
         }
 


### PR DESCRIPTION
When calculating star rating, the total strain value (difficulty value) is square-rooted and multiplied a constant. In single HitObject star approximation, strain value is not square-rooted, making the value incorrect.

For example, in loved AiAe, original algorithm gives 40*+ nearly every HitObject, which is far from actual star rating 13.95*. After the fix, it gives 15*, though it is still not very accurate but definitely better the original one.